### PR TITLE
add a proxy route for creation of new annotations

### DIFF
--- a/nemo_annotator_plugin/__init__.py
+++ b/nemo_annotator_plugin/__init__.py
@@ -1,21 +1,37 @@
 from flask_nemo.plugin import PluginPrototype
 from pkg_resources import resource_filename
-from flask import url_for, send_from_directory, Markup
-"""from nemo_oauth_plugin import NemoOauthPlugin"""
+from flask import url_for, send_from_directory, Markup, request, jsonify, Response
+import requests
+from nemo_oauth_plugin import NemoOauthPlugin
 
 
 class AnnotatorPlugin(PluginPrototype):
+    """ Perseids Annotator Plugin for Nemo
+
+    :param annotation_store
+    :type URL of the annotation store's update endpoint
+
+    :ivar interface: QueryInterface used to retrieve annotations
+    :cvar HAS_AUGMENT_RENDER: (True) Adds a stack of render
+
+    """
     HAS_AUGMENT_RENDER = True
     TEMPLATES = {
         "annotator": resource_filename("nemo_annotator_plugin", "data/templates")
     }
 
     ROUTES = PluginPrototype.ROUTES + [
-        ("/annotator-assets/<path:filename>", "r_annotator_assets", ["GET"]),
+        ("/annotator/assets/<path:filename>", "r_annotator_assets", ["GET"]),
+        ("/annotator/proxy", "r_annotator_proxy", ["GET","POST"])
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, annotation_store, *args, **kwargs):
         super(AnnotatorPlugin, self).__init__(*args, **kwargs)
+        self.__annotation_store__ = annotation_store
+
+    @property
+    def annotation_store(self):
+        return self.__annotation_store__
 
     def render(self, **kwargs):
         update = kwargs
@@ -30,3 +46,41 @@ class AnnotatorPlugin(PluginPrototype):
         :return: Content of the file
         """
         return send_from_directory(resource_filename("nemo_annotator_plugin", "data/assets"), filename)
+
+    @NemoOauthPlugin.oauth_required
+    def r_annotator_proxy(self):
+        """ Proxy to write to the annotation store
+
+        :return: response from the remote query store
+        :rtype: {str: Any}
+        """
+
+        query = request.data
+
+        if self.is_authorized(query):
+            try:
+                resp = requests.post(self.annotation_store, data=query, json=None,
+                                     headers={"content-type": "application/sparql-update",
+                                              "accept": "application/sparql-results+json"})
+                resp.raise_for_status()
+                return resp.content, resp.status_code
+            except requests.exceptions.HTTPError as err:
+                return str(err), resp.status_code
+        else:
+            return "Unauthorized request", 403
+
+
+    def is_authorized(self,query):
+        """
+            Verify AuthZ conditions for an annotation query
+
+            :param the query
+            :type str
+
+            :return: True or false
+            :rtype bool
+        """
+        # TODO here we want to check the content of the query against the user_uri that's stored
+        # in the session to make sure they match
+        return True
+

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -1,3 +1,4 @@
 flask_nemo>=1.0.0b1
 capitains_nautilus>=0.0.5
-nemo_oauth_plugin>=0.0.1
+nemo_oauth_plugin>=0.0.2
+requests>=2.8.1


### PR DESCRIPTION
route is protected by oauth and is a pass through to the annotation store

@fbaumgardt 

I didn't yet implement checking the contents of the query against the user stored in the session -- but I pulled that out to a separate method at least.  I wasn't sure if we wanted to use a python/rdf library to try to understand the query, or to do a potentially crazy regex. Suggestions welcome on this!

Note that I've added the oauth protection on the proxy route itself, but it might be best to also have this on the view that ends up calling the route, so that the user is prompted before they get to the point of saving annotations. As the oauth plugin is currently implemented, it won't pass forward the body of the post of a request which was redirected to login, so it would be an unhappy user experience.  I can add that (and probably should at some point) but for now it might be sufficient to protect the text view, or the annotator widget.
